### PR TITLE
意図せず dbp:hoge となっている箇所があったので修正しました

### DIFF
--- a/ProtoToJsonld.py
+++ b/ProtoToJsonld.py
@@ -22,6 +22,8 @@ for elm in schemalist:
         schemasubClassOfs.append({'@id': 'schema:Thing'})
 
 PROTO_TYPE_TO_SCHEMA_TYPE = {
+    'int32': 'schema:Integer',
+    'bool': 'schema:Boolean',
     'string': 'schema:Text',
     'bytes': None,
     'float': 'schema:Float',
@@ -235,7 +237,6 @@ def ParseProto(protofile):
                             flag3 = 1
                             break
                     if flag3 == 0:
-                        # bool, int32 は↓に加えなくていい？ dbp:bool, dbp:int32 が出来上がってしまってる
                         if line[1] not in list(PROTO_TYPE_TO_SCHEMA_TYPE.keys()) + IGNORE_MESSAGES:
                             if line[1] == tmp_class.name:
                                 tmp_class.addParentClass(line[2])

--- a/ProtoToJsonld.py
+++ b/ProtoToJsonld.py
@@ -101,6 +101,8 @@ class DataSchema:
     def addChildClass(self, rangeInclude):
         if rangeInclude == 'string':
             t = {'@id': 'schema:Text'}
+        elif rangeInclude == 'float':
+            t = {'@id': 'schema:Float'}
         elif rangeInclude == 'google.protobuf.Struct':
             t = {'@id': 'schema:CreativeWork'}
         elif rangeInclude == 'google.protobuf.Timestamp':

--- a/ProtoToJsonld.py
+++ b/ProtoToJsonld.py
@@ -28,7 +28,8 @@ PROTO_TYPE_TO_SCHEMA_TYPE = {
     'bytes': None,
     'float': 'schema:Float',
     'google.protobuf.Struct': 'schema:CreativeWork',
-    'google.protobuf.Timestamp': 'schema:DateTime'
+    'google.protobuf.Timestamp': 'schema:DateTime',
+    'google.protobuf.StringValue': 'schema:Text',
 }
 
 RDFS_INFOS = [

--- a/ProtoToJsonld.py
+++ b/ProtoToJsonld.py
@@ -21,6 +21,14 @@ for elm in schemalist:
     else:
         schemasubClassOfs.append({'@id': 'schema:Thing'})
 
+PROTO_TYPE_TO_SCHEMA_TYPE = {
+    'string': 'schema:Text',
+    'bytes': None,
+    'float': 'schema:Float',
+    'google.protobuf.Struct': 'schema:CreativeWork',
+    'google.protobuf.Timestamp': 'schema:DateTime'
+}
+
 RDFS_INFOS = [
     {"id": "rdfs:comment", "comment": "an instance of rdf:Property that may be used to provide a human-readable description of a resource."},
     {"id": "rdfs:label", "comment": "an instance of rdf:Property that may be used to provide a human-readable version of a resource's name."},
@@ -99,16 +107,12 @@ class DataSchema:
         self.domainIncludes.append(t)
 
     def addChildClass(self, rangeInclude):
-        if rangeInclude == 'string':
-            t = {'@id': 'schema:Text'}
-        elif rangeInclude == 'float':
-            t = {'@id': 'schema:Float'}
-        elif rangeInclude == 'google.protobuf.Struct':
-            t = {'@id': 'schema:CreativeWork'}
-        elif rangeInclude == 'google.protobuf.Timestamp':
-            t = {'@id': 'schema:DateTime'}
-        else:
-            t = {'@id': DbpOrSchema(rangeInclude)}
+        for proto_type, schema_type in PROTO_TYPE_TO_SCHEMA_TYPE.items():
+            if rangeInclude == proto_type and schema_type is not None:
+                t = {'@id': schema_type}
+                self.rangeIncludes.append(t)
+                return
+        t = {'@id': DbpOrSchema(rangeInclude)}
         self.rangeIncludes.append(t)
 
     def getJsonld(self):
@@ -232,7 +236,7 @@ def ParseProto(protofile):
                             break
                     if flag3 == 0:
                         # bool, int32 は↓に加えなくていい？ dbp:bool, dbp:int32 が出来上がってしまってる
-                        if line[1] not in ['string', 'bytes', 'float', 'google.protobuf.Struct', 'google.protobuf.Timestamp'] + IGNORE_MESSAGES:
+                        if line[1] not in list(PROTO_TYPE_TO_SCHEMA_TYPE.keys()) + IGNORE_MESSAGES:
                             if line[1] == tmp_class.name:
                                 tmp_class.addParentClass(line[2])
                             else:

--- a/dbp-schema.ja.jsonld
+++ b/dbp-schema.ja.jsonld
@@ -1468,19 +1468,6 @@
       }
     },
     {
-      "@id": "dbp:google.protobuf.StringValue",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "",
-      "rdfs:label": "google.protobuf.StringValue",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:domainIncludes": {
-        "@id": "schema:unitText"
-      },
-      "schema:rangeIncludes": []
-    },
-    {
       "@id": "dbp:isMostlyConstant",
       "@type": "rdf:Property",
       "rdfs:comment": "データフィールドがほとんど一定値かどうか",

--- a/dbp-schema.ja.jsonld
+++ b/dbp-schema.ja.jsonld
@@ -990,68 +990,8 @@
         "@id": "dbp:RealWorldDataFieldProfile"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
-    },
-    {
-      "@id": "dbp:bool",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "",
-      "rdfs:label": "bool",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:domainIncludes": [
-        {
-          "@id": "dbp:jsonHasIndent"
-        },
-        {
-          "@id": "dbp:csvHasHeader"
-        },
-        {
-          "@id": "dbp:csvVariableColumnsStripTrailingCommas"
-        },
-        {
-          "@id": "dbp:dbpaCompress"
-        },
-        {
-          "@id": "dbp:StripTrailingZeros"
-        },
-        {
-          "@id": "dbp:UseRunLength"
-        },
-        {
-          "@id": "dbp:UseFFTCompression"
-        },
-        {
-          "@id": "dbp:isMostlyConstant"
-        },
-        {
-          "@id": "dbp:isEnumValue"
-        },
-        {
-          "@id": "dbp:isMostlyIncremental"
-        },
-        {
-          "@id": "dbp:isNullable"
-        },
-        {
-          "@id": "dbp:isOptional"
-        },
-        {
-          "@id": "dbp:dbpaDateTimeFormatUtcIsUTCinRFC3339"
-        },
-        {
-          "@id": "dbp:dbpaDateTimeFormatUtcIsZinRFC3339"
-        },
-        {
-          "@id": "dbp:UseBaseIncrement"
-        },
-        {
-          "@id": "dbp:enabled"
-        }
-      ],
-      "schema:rangeIncludes": []
     },
     {
       "@id": "dbp:jsonIndentCharacter",
@@ -1074,7 +1014,7 @@
         "@id": "dbp:RealWorldDataFieldProfile"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1110,7 +1050,7 @@
         "@id": "dbp:RealWorldDataFieldProfile"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1161,59 +1101,8 @@
         "@id": "dbp:DbpClass"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
-    },
-    {
-      "@id": "dbp:int32",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "",
-      "rdfs:label": "int32",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:domainIncludes": [
-        {
-          "@id": "dbp:dbpaCompressRowID"
-        },
-        {
-          "@id": "dbp:dbpaCompressListID"
-        },
-        {
-          "@id": "dbp:dbpaChildrenLists"
-        },
-        {
-          "@id": "dbp:dbpaCompressParentListId"
-        },
-        {
-          "@id": "dbp:dbpaCompressColumnId"
-        },
-        {
-          "@id": "dbp:dbpaDiffNumBytes"
-        },
-        {
-          "@id": "dbp:dbpaFirstNumBytes"
-        },
-        {
-          "@id": "dbp:dbpaDatetimeDiffBytes"
-        },
-        {
-          "@id": "dbp:dbpaDateTimeFormatOffset"
-        },
-        {
-          "@id": "dbp:dbpaTimestampRepresentingColumns"
-        },
-        {
-          "@id": "dbp:PrecisionBytes"
-        },
-        {
-          "@id": "dbp:DecimalPlaces"
-        },
-        {
-          "@id": "dbp:transmissionSpeed"
-        }
-      ],
-      "schema:rangeIncludes": []
     },
     {
       "@id": "dbp:DbpList",
@@ -1257,7 +1146,7 @@
         "@id": "dbp:DbpList"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1269,7 +1158,7 @@
         "@id": "dbp:DbpList"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1281,7 +1170,7 @@
         "@id": "dbp:DbpList"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1437,7 +1326,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1449,7 +1338,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1461,7 +1350,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1473,7 +1362,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1485,7 +1374,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1497,7 +1386,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1533,7 +1422,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1600,7 +1489,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1612,7 +1501,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1624,7 +1513,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1636,7 +1525,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1648,7 +1537,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1684,7 +1573,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1696,7 +1585,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1708,7 +1597,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1720,7 +1609,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1732,7 +1621,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1780,7 +1669,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1792,7 +1681,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1816,7 +1705,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1864,7 +1753,7 @@
         "@id": "dbp:RealWorldDataStoringInfo"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -2414,7 +2303,7 @@
         }
       ],
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {

--- a/dbp-schema.ja.jsonld
+++ b/dbp-schema.ja.jsonld
@@ -1521,7 +1521,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:float"
+        "@id": "schema:Float"
       }
     },
     {

--- a/dbp-schema.jsonld
+++ b/dbp-schema.jsonld
@@ -1468,19 +1468,6 @@
       }
     },
     {
-      "@id": "dbp:google.protobuf.StringValue",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "",
-      "rdfs:label": "google.protobuf.StringValue",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:domainIncludes": {
-        "@id": "schema:unitText"
-      },
-      "schema:rangeIncludes": []
-    },
-    {
       "@id": "dbp:isMostlyConstant",
       "@type": "rdf:Property",
       "rdfs:comment": "Whether the data field is mostly constant",

--- a/dbp-schema.jsonld
+++ b/dbp-schema.jsonld
@@ -990,68 +990,8 @@
         "@id": "dbp:RealWorldDataFieldProfile"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
-    },
-    {
-      "@id": "dbp:bool",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "",
-      "rdfs:label": "bool",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:domainIncludes": [
-        {
-          "@id": "dbp:jsonHasIndent"
-        },
-        {
-          "@id": "dbp:csvHasHeader"
-        },
-        {
-          "@id": "dbp:csvVariableColumnsStripTrailingCommas"
-        },
-        {
-          "@id": "dbp:dbpaCompress"
-        },
-        {
-          "@id": "dbp:StripTrailingZeros"
-        },
-        {
-          "@id": "dbp:UseRunLength"
-        },
-        {
-          "@id": "dbp:UseFFTCompression"
-        },
-        {
-          "@id": "dbp:isMostlyConstant"
-        },
-        {
-          "@id": "dbp:isEnumValue"
-        },
-        {
-          "@id": "dbp:isMostlyIncremental"
-        },
-        {
-          "@id": "dbp:isNullable"
-        },
-        {
-          "@id": "dbp:isOptional"
-        },
-        {
-          "@id": "dbp:dbpaDateTimeFormatUtcIsUTCinRFC3339"
-        },
-        {
-          "@id": "dbp:dbpaDateTimeFormatUtcIsZinRFC3339"
-        },
-        {
-          "@id": "dbp:UseBaseIncrement"
-        },
-        {
-          "@id": "dbp:enabled"
-        }
-      ],
-      "schema:rangeIncludes": []
     },
     {
       "@id": "dbp:jsonIndentCharacter",
@@ -1074,7 +1014,7 @@
         "@id": "dbp:RealWorldDataFieldProfile"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1110,7 +1050,7 @@
         "@id": "dbp:RealWorldDataFieldProfile"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1161,59 +1101,8 @@
         "@id": "dbp:DbpClass"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
-    },
-    {
-      "@id": "dbp:int32",
-      "@type": "rdfs:Class",
-      "rdfs:comment": "",
-      "rdfs:label": "int32",
-      "rdfs:subClassOf": {
-        "@id": "schema:Thing"
-      },
-      "schema:domainIncludes": [
-        {
-          "@id": "dbp:dbpaCompressRowID"
-        },
-        {
-          "@id": "dbp:dbpaCompressListID"
-        },
-        {
-          "@id": "dbp:dbpaChildrenLists"
-        },
-        {
-          "@id": "dbp:dbpaCompressParentListId"
-        },
-        {
-          "@id": "dbp:dbpaCompressColumnId"
-        },
-        {
-          "@id": "dbp:dbpaDiffNumBytes"
-        },
-        {
-          "@id": "dbp:dbpaFirstNumBytes"
-        },
-        {
-          "@id": "dbp:dbpaDatetimeDiffBytes"
-        },
-        {
-          "@id": "dbp:dbpaDateTimeFormatOffset"
-        },
-        {
-          "@id": "dbp:dbpaTimestampRepresentingColumns"
-        },
-        {
-          "@id": "dbp:PrecisionBytes"
-        },
-        {
-          "@id": "dbp:DecimalPlaces"
-        },
-        {
-          "@id": "dbp:transmissionSpeed"
-        }
-      ],
-      "schema:rangeIncludes": []
     },
     {
       "@id": "dbp:DbpList",
@@ -1257,7 +1146,7 @@
         "@id": "dbp:DbpList"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1269,7 +1158,7 @@
         "@id": "dbp:DbpList"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1281,7 +1170,7 @@
         "@id": "dbp:DbpList"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1437,7 +1326,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1449,7 +1338,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1461,7 +1350,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1473,7 +1362,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1485,7 +1374,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1497,7 +1386,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1533,7 +1422,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1600,7 +1489,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1612,7 +1501,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1624,7 +1513,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1636,7 +1525,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1648,7 +1537,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1684,7 +1573,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1696,7 +1585,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1708,7 +1597,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1720,7 +1609,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1732,7 +1621,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1780,7 +1669,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1792,7 +1681,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -1816,7 +1705,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {
@@ -1864,7 +1753,7 @@
         "@id": "dbp:RealWorldDataStoringInfo"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:int32"
+        "@id": "schema:Integer"
       }
     },
     {
@@ -2414,7 +2303,7 @@
         }
       ],
       "schema:rangeIncludes": {
-        "@id": "dbp:bool"
+        "@id": "schema:Boolean"
       }
     },
     {

--- a/dbp-schema.jsonld
+++ b/dbp-schema.jsonld
@@ -1521,7 +1521,7 @@
         "@id": "dbp:RealWorldDataStructureProperty"
       },
       "schema:rangeIncludes": {
-        "@id": "dbp:float"
+        "@id": "schema:Float"
       }
     },
     {


### PR DESCRIPTION
（キャピタライズの統一に取りかかろうとしたら、本PRに関する未コミットの diff があったため、一旦こちらを片してます）

- dbp:float → schema:Float
- dbp:int32 → schema:Integer
- dbp:bool → schema:Boolean

dbp:bytes ですが、それに相当する schema.org のタイプが見つけられなかったため、一旦保留にしています。
byte で探すと、[MediaObject](https://schema.org/MediaObject) などが相当して、その中でその実態を指すのは contentUrl → schema:URL となっていて、バイナリデータそのものを指すものは、見つけられなかったです。