### PR TITLE
docs: README サンプルの `dbp:dbpaDateTimeFormat` を正式名 `dbp:dbpaDatetimeFormat` に訂正

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ protoc -I . --go_out=paths=source_relative:. --experimental_allow_proto3_optiona
             "@id": "class1"
           },
           "dbp:variableScaleType": "Interval",
-          "dbp:dbpaDateTimeFormat": "%Y-%m-%dT%H:%M:%S",
+          "dbp:dbpaDatetimeFormat": "%Y-%m-%dT%H:%M:%S",
           "dbp:dbpaCompressParentListID": 0,
           "dbp:dbpaCompressColumnID": 0
         },
@@ -296,7 +296,7 @@ protoc -I . --go_out=paths=source_relative:. --experimental_allow_proto3_optiona
             "@id": "class1"
           },
           "dbp:variableScaleType": "Interval",
-          "dbp:dbpaDateTimeFormat": "%Y-%m-%dT%H:%M:%S",
+          "dbp:dbpaDatetimeFormat": "%Y-%m-%dT%H:%M:%S",
           "dbp:dbpaCompressParentListID": 0,
           "dbp:dbpaCompressColumnID": 0
         },
@@ -313,7 +313,7 @@ protoc -I . --go_out=paths=source_relative:. --experimental_allow_proto3_optiona
             "@id": "class1"
           },
           "dbp:variableScaleType": "Interval",
-          "dbp:dbpaDateTimeFormat": "%Y-%m-%dT%H:%M:%S",
+          "dbp:dbpaDatetimeFormat": "%Y-%m-%dT%H:%M:%S",
           "dbp:dbpaCompressParentListID": 0,
           "dbp:dbpaCompressColumnID": 1
         },


### PR DESCRIPTION
Fixes #21

## 原因

`README.md` のサンプル JSON-LD 3 箇所（L100 / L299 / L316）が、本リポジトリのどの正本にも
定義されていない `dbp:dbpaDateTimeFormat`（**`T` が大文字**）を使っていました。

正式なプロパティ名は `dbp:dbpaDatetimeFormat`（**`t` が小文字**）で、正本はいずれも
小文字で定義しています:

| 正本 | 定義箇所 |
|---|---|
| `dbp-schema.jsonld` | L1615 `"@id": "dbp:dbpaDatetimeFormat"` / L1618 `rdfs:label` |
| `dbp-schema.ja.jsonld` | L1615 / L1618 |
| `dbp_schema.proto` | L254 (`StructureProperty`) / L553 (`DataFieldType`) |
| `dbp_schema.sql` | L367 |
| `dbp_schema.pb.go` | L1884 / L4304 |

サンプルは実装者のコピペ元になりやすく、誤表記の伝播源になり得ます。実際に
exdata-inc/semantipack#11 では利用側リポジトリ（`dbp-dbpa-compressor` / `semantipack-web`）に
同じ誤表記が入り込んでおり、そちらも別途訂正中です。

## 修正内容

README.md のサンプル 3 箇所を正式名に訂正しました（**3 行の rename のみ**、他の変更なし）。

```diff
-          "dbp:dbpaDateTimeFormat": "%Y-%m-%dT%H:%M:%S",
+          "dbp:dbpaDatetimeFormat": "%Y-%m-%dT%H:%M:%S",
```

## ⚠️ 一括置換していません

同じ接頭辞を持つ **別プロパティ 3 つは大文字 `T` が正式名** です。
`sed s/dbpaDateTimeFormat/dbpaDatetimeFormat/g` のような一括置換をするとこれらまで壊れるため、
`"dbp:dbpaDateTimeFormat":` という **裸の形だけ** を対象にしています。

| プロパティ | 本 PR での扱い |
|---|---|
| `dbp:dbpaDateTimeFormatOffset` | **変更なし**（大文字 `T` が正式名） |
| `dbp:dbpaDateTimeFormatUtcIsUTCinRFC3339` | **変更なし** |
| `dbp:dbpaDateTimeFormatUtcIsZinRFC3339` | **変更なし** |

## 確認方法

```bash
# 1. 裸の大文字 T が repo 全体から消えたこと（3 兄弟を除外して検索）→ 0 件
grep -rn "dbpaDateTimeFormat" . -I | grep -v "dbpaDateTimeFormat\(Offset\|UtcIs\)"

# 2. 3 兄弟が無傷であること → jsonld 9 件 / proto 3 件（変更前と同数）
grep -rc "dbpaDateTimeFormatOffset\|dbpaDateTimeFormatUtcIs" dbp-schema.jsonld dbp_schema.proto

# 3. 差分が README.md の 3 行だけであること
git diff --stat main...HEAD   # README.md | 6 +++---
```

正本（`.jsonld` / `.proto` / `.sql` / `.pb.go`）には一切手を入れていないため、
生成物の再生成やスキーマ互換性への影響はありません。
